### PR TITLE
Add interactive mode and an option to download the last n most recent lectures

### DIFF
--- a/mlrd/__main__.py
+++ b/mlrd/__main__.py
@@ -13,8 +13,14 @@ def start():
     
     parser.add_argument("auth_token", help="A fresh bearer authorization token for MyCourses")
 
+    # interactive mode to promt user before downloading each lecture
+    parser.add_argument("-i", "--interactive", help="Interactive mode", action="store_true")
+
+    # option to only download the last n lectures
+    parser.add_argument("-n", "--last_n", help="Only download the last n lectures, by date created. Interactive mode is ignored.", type=int, default=None)
+
     args = parser.parse_args()
-    run(args.course_id, args.output_dir, args.auth_token)
+    run(args.course_id, args.output_dir, args.auth_token, args.interactive, args.last_n)
 
 def main():
     start()

--- a/mlrd/__main__.py
+++ b/mlrd/__main__.py
@@ -13,11 +13,11 @@ def start():
     
     parser.add_argument("auth_token", help="A fresh bearer authorization token for MyCourses")
 
-    # interactive mode to promt user before downloading each lecture
+    # interactive mode to prompt user before downloading each lecture
     parser.add_argument("-i", "--interactive", help="Interactive mode", action="store_true")
 
     # option to only download the last n lectures
-    parser.add_argument("-n", "--last_n", help="Only download the last n lectures, by date created. Interactive mode is ignored.", type=int, default=None)
+    parser.add_argument("-n", "--last_n", help="Only download the last n lectures, by date created.", type=int, default=None)
 
     args = parser.parse_args()
     run(args.course_id, args.output_dir, args.auth_token, args.interactive, args.last_n)

--- a/mlrd/mlrd.py
+++ b/mlrd/mlrd.py
@@ -54,11 +54,22 @@ def download(in_file, out_file, duration):
     
     print('\n')
 
-def run(course_id, output_dir, auth_token):
+def run(course_id, output_dir, auth_token, interactive=False, last_n=None):
     course_dto = get_media_recordings_dto(course_id, auth_token)
     date_format = 'YYYY-MM-DD'
+    lectures_to_download = course_dto if not interactive else []
 
-    for lecture in course_dto:
+    # interactive and last_n will NOT be used together
+    if interactive and last_n is None:
+        for lecture in course_dto:
+            print('\nLecture: {} | Date: {} | Description: {}'.format(lecture['recordingName'], lecture['dateTime'], lecture['description']))
+            if input('Download lecture? y/n: ') != 'y':
+                lectures_to_download.append(lecture)
+    
+    if last_n is not None:
+        lectures_to_download = sorted(course_dto, key=lambda x: x['dateTime'], reverse=True)[:last_n]
+
+    for lecture in lectures_to_download:
         date = lecture['dateTime'][:len(date_format)]
         duration = int(lecture['durationSeconds'])
         id = lecture['recordingInt']

--- a/mlrd/mlrd.py
+++ b/mlrd/mlrd.py
@@ -57,17 +57,16 @@ def download(in_file, out_file, duration):
 def run(course_id, output_dir, auth_token, interactive=False, last_n=None):
     course_dto = get_media_recordings_dto(course_id, auth_token)
     date_format = 'YYYY-MM-DD'
-    lectures_to_download = course_dto if not interactive else []
+    nlectures = sorted(course_dto, key=lambda x: x['dateTime'], reverse=True)[:last_n] if last_n is not None else course_dto
+    lectures_to_download = []
 
-    # interactive and last_n will NOT be used together
-    if interactive and last_n is None:
-        for lecture in course_dto:
+    if interactive:
+        for lecture in nlectures:
             print('\nLecture: {} | Date: {} | Description: {}'.format(lecture['recordingName'], lecture['dateTime'], lecture['description']))
             if input('Download lecture? y/n: ') != 'y':
                 lectures_to_download.append(lecture)
-    
-    if last_n is not None:
-        lectures_to_download = sorted(course_dto, key=lambda x: x['dateTime'], reverse=True)[:last_n]
+    else:
+        lectures_to_download = nlectures
 
     for lecture in lectures_to_download:
         date = lecture['dateTime'][:len(date_format)]

--- a/mlrd/mlrd.py
+++ b/mlrd/mlrd.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import subprocess as sp
 import sys
 import shlex
+from os import path, name as os_name
 
 '''
     Returns a DTO containing information about a given course's lectures.
@@ -35,8 +36,8 @@ def print_progress(percent: float, duration_down: int, total_duration: int, elap
 
 def download(in_file, out_file, duration):
     commands = shlex.split(
-        'ffmpeg -nostats -loglevel 0 -progress - -protocol_whitelist file,http,https,tcp,tls,crypto -i {} -c copy {}'.format(in_file, out_file)
-        )
+        'ffmpeg -nostats -loglevel 0 -progress - -protocol_whitelist file,http,https,tcp,tls,crypto -i {} -c copy {}'.format(in_file, out_file),
+        posix=os_name=='posix')
     start = datetime.now()
     out_time_prefix = "out_time_us="
     p = sp.Popen(commands, shell=False, stdout=sp.PIPE)
@@ -61,11 +62,14 @@ def run(course_id, output_dir, auth_token):
         date = lecture['dateTime'][:len(date_format)]
         duration = int(lecture['durationSeconds'])
         id = lecture['recordingInt']
-        file_name = "{}_{}.mp4".format(id, date)
+        file_name = "{}_{}_{}.mp4".format(lecture['recordingName'].replace(' ', '-'), id, date)
         print('Downloading lecture from {} to {} ...'.format(date, file_name))
 
         m3u8 = get_m3u8_stream(lecture)
-        out = output_dir + file_name
+        
+        if not path.isdir(output_dir):
+            raise RuntimeError('Output directory does not exist: {}'.format(output_dir))
+        out = path.join(output_dir, file_name)
         download(m3u8, out, duration)
 
         print('Lecture {} downloaded to {}'.format(file_name, output_dir))


### PR DESCRIPTION
## -i, -n

This would add two more optional arguments: `-i` and `-n`.

- `-i, --interactive`: Starts an interactive mode when downloading lectures, by prompting the user to confirm before each download starts.
- `-n, --last_n`: Will only download the last `n` most recent lectures, sorted by date uploaded.

I think adding these features could help make using this project a lot easier. Sometimes students just want the most recent lecture to download, instead of the whole thing every time.

## Support downloading into correct output directories on non-posix operating systems
There is also a small fix that allows mlrd to actually download the videos into the specified `output_dir` on non-posix operating systems. 